### PR TITLE
#6: Removed offending JavaDoc tags.

### DIFF
--- a/spring-boot-legacy/src/main/java/org/springframework/boot/legacy/context/web/AnnotationConfigNonEmbeddedWebApplicationContext.java
+++ b/spring-boot-legacy/src/main/java/org/springframework/boot/legacy/context/web/AnnotationConfigNonEmbeddedWebApplicationContext.java
@@ -30,11 +30,7 @@ import org.springframework.util.Assert;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
 /**
- * {@link EmbeddedWebApplicationContext} that accepts annotated classes as input - in
- * particular {@link org.springframework.context.annotation.Configuration
- * <code>@Configuration</code>}-annotated classes, but also plain
- * {@link org.springframework.stereotype.Component <code>@Component</code>} classes and
- * JSR-330 compliant classes using {@code javax.inject} annotations. Allows for
+ * {@link EmbeddedWebApplicationContext} that accepts annotated classes as input. Allows for
  * registering classes one by one (specifying class names as config location) as well as
  * for classpath scanning (specifying base packages as config location).
  * <p>
@@ -43,7 +39,7 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
  * to deliberately override certain bean definitions via an extra Configuration class.
  * 
  * @author Phillip Webb
- * @Author Dave Syer
+ * @author Dave Syer
  * @see #register(Class...)
  * @see #scan(String...)
  * @see EmbeddedWebApplicationContext
@@ -74,8 +70,7 @@ public class AnnotationConfigNonEmbeddedWebApplicationContext extends
 	 * Create a new {@link AnnotationConfigNonEmbeddedWebApplicationContext}, deriving
 	 * bean definitions from the given annotated classes and automatically refreshing the
 	 * context.
-	 * @param annotatedClasses one or more annotated classes, e.g. {@link Configuration
-	 * <code>@Configuration</code>} classes
+	 * @param annotatedClasses one or more annotated classes, 
 	 */
 	public AnnotationConfigNonEmbeddedWebApplicationContext(Class<?>... annotatedClasses) {
 		this();
@@ -117,6 +112,7 @@ public class AnnotationConfigNonEmbeddedWebApplicationContext extends
 	 * <p>
 	 * Any call to this method must occur prior to calls to {@link #register(Class...)}
 	 * and/or {@link #scan(String...)}.
+	 * @param beanNameGenerator bean name generator
 	 * @see AnnotatedBeanDefinitionReader#setBeanNameGenerator
 	 * @see ClassPathBeanDefinitionScanner#setBeanNameGenerator
 	 */
@@ -135,6 +131,7 @@ public class AnnotationConfigNonEmbeddedWebApplicationContext extends
 	 * <p>
 	 * Any call to this method must occur prior to calls to {@link #register(Class...)}
 	 * and/or {@link #scan(String...)}.
+	 * @param scopeMetadataResolver scope metadata resolver
 	 */
 	public void setScopeMetadataResolver(ScopeMetadataResolver scopeMetadataResolver) {
 		this.reader.setScopeMetadataResolver(scopeMetadataResolver);
@@ -148,8 +145,7 @@ public class AnnotationConfigNonEmbeddedWebApplicationContext extends
 	 * <p>
 	 * Calls to {@link #register} are idempotent; adding the same annotated class more
 	 * than once has no additional effect.
-	 * @param annotatedClasses one or more annotated classes, e.g. {@link Configuration
-	 * <code>@Configuration</code>} classes
+	 * @param annotatedClasses one or more annotated classes
 	 * @see #scan(String...)
 	 * @see #refresh()
 	 */


### PR DESCRIPTION
Not sure why JavaDoc is complaining about these tags, but these changes eliminate the problem.