### PR TITLE
Use ConfigurableWebApplicationContext as type parameter for ApplicationContextInitializer

### DIFF
--- a/spring-boot-legacy/src/main/java/org/springframework/boot/legacy/context/web/SpringBootContextLoaderListener.java
+++ b/spring-boot-legacy/src/main/java/org/springframework/boot/legacy/context/web/SpringBootContextLoaderListener.java
@@ -27,7 +27,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.GenericWebApplicationContext;
+import org.springframework.web.context.ConfigurableWebApplicationContext;
 
 /**
  * A {@link ContextLoaderListener} that uses {@link SpringApplication} to initialize an
@@ -52,9 +52,9 @@ public class SpringBootContextLoaderListener extends ContextLoaderListener {
 		@SuppressWarnings("unchecked")
 		Class<? extends ConfigurableApplicationContext> contextClass = (Class<? extends ConfigurableApplicationContext>) determineContextClass(servletContext);
 		builder.contextClass(contextClass);
-		builder.initializers(new ApplicationContextInitializer<GenericWebApplicationContext>() {
+		builder.initializers(new ApplicationContextInitializer<ConfigurableWebApplicationContext>() {
 			@Override
-			public void initialize(GenericWebApplicationContext applicationContext) {
+			public void initialize(ConfigurableWebApplicationContext applicationContext) {
 				applicationContext.setServletContext(servletContext);
 			}
 		});


### PR DESCRIPTION
When using an application context that inherits from AbstractRefreshableApplicationContext the starting of the application fails with the following message:

```
01-Oct-2015 15:54:11.781 SEVERE [localhost-startStop-1] org.apache.catalina.core.StandardContext.listenerStart Exception sending context initialized event to listener instance of class org.springframework.boot.legacy.context.web.SpringBootContextLoaderListener
 java.lang.IllegalArgumentException: Unable to call initializer. Object of class [org.springframework.web.context.support.AnnotationConfigWebApplicationContext] must be an instance of class org.springframework.web.context.support.GenericWebApplicationContext
        at org.springframework.util.Assert.isInstanceOf(Assert.java:339)
        at org.springframework.boot.SpringApplication.applyInitializers(SpringApplication.java:567)
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:304)
        at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:139)
        at org.springframework.boot.legacy.context.web.SpringBootContextLoaderListener.initWebApplicationContext(SpringBootContextLoaderListener.java:61)
        at org.springframework.web.context.ContextLoaderListener.contextInitialized(ContextLoaderListener.java:106)
        at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4961)
        at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5455)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
        at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:901)
        at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:877)
        at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:634)
        at org.apache.catalina.startup.HostConfig.deployWAR(HostConfig.java:1074)
        at org.apache.catalina.startup.HostConfig$DeployWar.run(HostConfig.java:1858)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
        at java.util.concurrent.FutureTask.run(FutureTask.java:262)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
```

This pull request fixes this problem.
